### PR TITLE
chore: attempt to enable streaming

### DIFF
--- a/src/domain/mathematician.ts
+++ b/src/domain/mathematician.ts
@@ -24,6 +24,7 @@ export class ClusterProblem extends Schema.TaggedError<ClusterProblem>(
 
 export const Mathematician = Entity.make("Mathematician", [
   Rpc.make("CalculateFibonacci", {
+    stream: true,
     payload: {
       target: Schema.Int,
     },


### PR DESCRIPTION
Naively trying to enable RPC streaming, with the goal of streaming responses from an Entity to a cluster client

<img width="507" alt="Screenshot 2025-04-06 at 17 47 03" src="https://github.com/user-attachments/assets/1902b20b-c0e8-439e-960e-a15a871cff91" />

```ts
src/domain/mathematician.ts:78:3 - error TS2345: Argument of type 'Effect<{ CalculateFibonacci: (args_0: Request<Rpc<"CalculateFibonacci", Struct<{ target: typeof Int; }>, Stream<Struct<{ result: typeof Int; mathematician: typeof String$; }>, Union<[typeof TooMuchMath, typeof BadLuckMath, typeof ProblemMathing, typeof ClusterProblem]>>, typeof Never, never>>) => Effect<...>; }, nev...' is not assignable to parameter of type 'HandlersFrom<Rpc<"CalculateFibonacci", Struct<{ target: typeof Int; }>, Stream<Struct<{ result: typeof Int; mathematician: typeof String$; }>, Union<[typeof TooMuchMath, typeof BadLuckMath, typeof ProblemMathing, typeof ClusterProblem]>>, typeof Never, never>> | Effect<...>'.
  Type 'Effect<{ CalculateFibonacci: (args_0: Request<Rpc<"CalculateFibonacci", Struct<{ target: typeof Int; }>, Stream<Struct<{ result: typeof Int; mathematician: typeof String$; }>, Union<[typeof TooMuchMath, typeof BadLuckMath, typeof ProblemMathing, typeof ClusterProblem]>>, typeof Never, never>>) => Effect<...>; }, nev...' is not assignable to type 'Effect<HandlersFrom<Rpc<"CalculateFibonacci", Struct<{ target: typeof Int; }>, Stream<Struct<{ result: typeof Int; mathematician: typeof String$; }>, Union<[typeof TooMuchMath, typeof BadLuckMath, typeof ProblemMathing, typeof ClusterProblem]>>, typeof Never, never>>, never, CurrentAddress | Sharding>' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
    Type '{ CalculateFibonacci: (args_0: Entity.Request<Rpc.Rpc<"CalculateFibonacci", Schema.Struct<{ target: typeof Schema.Int; }>, Stream<Schema.Struct<{ result: typeof Schema.Int; mathematician: typeof Schema.String; }>, Schema.Union<...>>, typeof Schema.Never, never>>) => Effect.Effect<...>; }' is not assignable to type 'HandlersFrom<Rpc<"CalculateFibonacci", Struct<{ target: typeof Int; }>, Stream<Struct<{ result: typeof Int; mathematician: typeof String$; }>, Union<[typeof TooMuchMath, typeof BadLuckMath, typeof ProblemMathing, typeof ClusterProblem]>>, typeof Never, never>>'.
      The types returned by 'CalculateFibonacci(...)' are incompatible between these types.
        Type 'Effect<{ result: number; mathematician: string; }, unknown, unknown>' is not assignable to type 'Stream<{ readonly result: number; readonly mathematician: string; }, ProblemMathing | TooMuchMath | BadLuckMath | ClusterProblem, any> | Effect<...> | Fork<...>'.
          Type 'Effect<{ result: number; mathematician: string; }, unknown, unknown>' is not assignable to type 'Effect<ReadonlyMailbox<{ readonly result: number; readonly mathematician: string; }, ProblemMathing | TooMuchMath | BadLuckMath | ClusterProblem>, ProblemMathing | ... 2 more ... | ClusterProblem, any>' with 'exactOptionalPropertyTypes: true'. Consider adding 'undefined' to the types of the target's properties.
            Type '{ result: number; mathematician: string; }' is missing the following properties from type 'ReadonlyMailbox<{ readonly result: number; readonly mathematician: string; }, ProblemMathing | TooMuchMath | BadLuckMath | ClusterProblem>': clear, takeAll, takeN, take, and 12 more.

 78   Effect.gen(function* () {
      ~~~~~~~~~~~~~~~~~~~~~~~~~
 79     const address = yield* Entity.CurrentAddress;
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
... 
181     };
    ~~~~~~
182   })
    ~~~~
```